### PR TITLE
Fix version in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuDGE"
 uuid = "7600667b-db04-5866-8f94-e5ff75fe7256"
 authors = ["Regan Baucke, Anthony Downward"]
-version = "0.91"
+version = "0.1.0"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"


### PR DESCRIPTION
This `version` field is only relevant when the package is properly registered. There is no benefit to changing it prior to then. 

It should also have three numbers, and follow https://semver.org. As a summary of SerVer, the version is MAJOR.MINOR.PATCH
 * Before making a release with a breaking change, increment MAJOR
 * Before making a release with a new feature, increment MINOR
 * Before making a release with a bug fix, increment PATCH

An exception is when the package is still in development (like JuMP, SDDP, etc).
* Keep MAJOR at 0
 * Before making a release with a breaking change, increment MINOR
 * Before making a release with new features or bug patches, increment PATCH

I would merge this as 0.1.0, and then ignore it for a while until the package is ready for registration.