### PR TITLE
Add [compat] and DelimitedFiles to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,15 @@ JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[compat]
+DataStructures = "0.18"
+JuMP = "0.21"
+
 [extras]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["GLPK", "Random", "Test"]
+test = ["DelimitedFiles", "GLPK", "Random", "Test"]


### PR DESCRIPTION
Closes #38 

The failure was because `DelimitedFiles` is a standard library package. In Julia 1.0 you could load any standard library without needing to declare it in your `Project.toml` file. In some version (I forget which), they changed this. I think the argument was that it didn't break anyone's code because the `.jl` source didn't need to change, only the `Project.toml` file...

I also added a compat section which is needed before you can register the package.